### PR TITLE
Update API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.pip
 
 # Spyder project settings
 .spyderproject

--- a/django_light_enums/db.py
+++ b/django_light_enums/db.py
@@ -9,7 +9,7 @@ class EnumField(IntegerField):
     """
 
     def __init__(self, enum, *args, **kwargs):
-        kwargs['choices'] = enum.choices()
+        kwargs['choices'] = enum.choices
         kwargs.setdefault('default', min(enum.enum_values))
         self.enum = enum
         return super(EnumField, self).__init__(*args, **kwargs)
@@ -19,7 +19,7 @@ class EnumField(IntegerField):
         if value is None:
             if not self.null:
                 raise ValidationError(_('None is not a valid value in this non-null enum.'))
-        elif value not in self.enum.enum_values:
+        elif not self.enum.is_valid_value(value):
             raise ValidationError(
                 _('(%(value)s) is not a valid value in this enum. '
                   'Possible values are: %(values)s.'),
@@ -27,7 +27,7 @@ class EnumField(IntegerField):
                     'value': value,
                     'values': ', '.join(
                         '{} ({})'.format(name, value)
-                        for value, name in self.enum.choices()
+                        for value, name in self.enum.choices
                     ),
                 },
             )

--- a/django_light_enums/db.py
+++ b/django_light_enums/db.py
@@ -9,14 +9,17 @@ class EnumField(IntegerField):
     """
 
     def __init__(self, enum, *args, **kwargs):
-        kwargs['choices'] = enum._choices
-        kwargs.setdefault('default', min(enum._enum_values.keys()))
+        kwargs['choices'] = enum.choices()
+        kwargs.setdefault('default', min(enum.enum_values))
         self.enum = enum
         return super(EnumField, self).__init__(*args, **kwargs)
 
     def pre_save(self, model_instance, add):
         value = getattr(model_instance, self.attname)
-        if value not in self.enum._enum_values.keys():
+        if value is None:
+            if not self.null:
+                raise ValidationError(_('None is not a valid value in this non-null enum.'))
+        elif value not in self.enum.enum_values:
             raise ValidationError(
                 _('(%(value)s) is not a valid value in this enum. '
                   'Possible values are: %(values)s.'),
@@ -24,7 +27,7 @@ class EnumField(IntegerField):
                     'value': value,
                     'values': ', '.join(
                         '{} ({})'.format(name, value)
-                        for value, name in self.enum._enum_values.items()
+                        for value, name in self.enum.choices()
                     ),
                 },
             )

--- a/django_light_enums/enum.py
+++ b/django_light_enums/enum.py
@@ -34,11 +34,13 @@ class EnumType(type):
     def enum_names(cls):
         return cls._enum_values.values()
 
+    @property
     def choices(cls):
         return list(cls._enum_values.items())
 
-    def name_values(cls):
-        return [(name, value) for value, name in cls.choices()]
+    @property
+    def choices_inverse(cls):
+        return [(name, value) for value, name in cls._enum_values.items()]
 
 
 class Enum(with_metaclass(EnumType)):

--- a/django_light_enums/enum.py
+++ b/django_light_enums/enum.py
@@ -35,7 +35,7 @@ class EnumType(type):
         return cls._enum_values.values()
 
     def choices(cls):
-        return cls._enum_values.items()
+        return list(cls._enum_values.items())
 
     def name_values(cls):
         return [(name, value) for value, name in cls.choices()]

--- a/django_light_enums/enum.py
+++ b/django_light_enums/enum.py
@@ -4,22 +4,24 @@ from .db import EnumField
 
 EnumField = EnumField
 
+
 class EnumType(type):
 
     def __new__(mcl, name, bases, nmspc):
         cls = super(EnumType, mcl).__new__(mcl, name, bases, nmspc)
         cls._enum_values = {
             value: field for field, value in cls.__dict__.items()
-            if not callable(value) and not field.startswith('__')
+            if not callable(value) and not field.startswith('_')
         }
-        cls._choices = [(value, field) for field, value in cls._enum_values.items()]
         return cls
 
     def get_name(cls, value):
-        return cls._enum_values[value]
+        return cls._enum_values.get(value)
 
     def get_value(cls, name):
-        return getattr(cls, name)
+        if not name:
+            return None
+        return getattr(cls, name, None)
 
     def is_valid_value(cls, value):
         return value in cls._enum_values.keys()
@@ -33,7 +35,10 @@ class EnumType(type):
         return cls._enum_values.values()
 
     def choices(cls):
-        return list(cls._choices)
+        return cls._enum_values.items()
+
+    def name_values(cls):
+        return [(name, value) for value, name in cls.choices()]
 
 
 class Enum(with_metaclass(EnumType)):

--- a/django_light_enums/enum.py
+++ b/django_light_enums/enum.py
@@ -2,6 +2,7 @@ from six import with_metaclass
 
 from .db import EnumField
 
+EnumField = EnumField
 
 class EnumType(type):
 
@@ -30,6 +31,9 @@ class EnumType(type):
     @property
     def enum_names(cls):
         return cls._enum_values.values()
+
+    def choices(cls):
+        return list(cls._choices)
 
 
 class Enum(with_metaclass(EnumType)):

--- a/tests/test.py
+++ b/tests/test.py
@@ -61,4 +61,4 @@ class EnumFieldTests(TestCase):
                 obj.save()
 
     def test_choices(self):
-        self.assertEqual(Status.choices(), Status._enum_values.items())
+        self.assertEqual(Status.choices(), list(Status._enum_values.items()))

--- a/tests/test.py
+++ b/tests/test.py
@@ -59,3 +59,7 @@ class EnumFieldTests(TestCase):
             with self.assertRaises(ValidationError):
                 obj.status = INVALID_VALUE
                 obj.save()
+
+    def test_choices(self):
+        self.assertEqual(Status.choices(), Status._choices)
+        self.assertFalse(Status.choices() is Status._choices)

--- a/tests/test.py
+++ b/tests/test.py
@@ -25,7 +25,7 @@ class EnumTests(TestCase):
                 (Status.STATUS_TWO, 'STATUS_TWO'),
                 (Status.STATUS_THREE, 'STATUS_THREE')
             ],
-            Status.choices()
+            Status.choices
         )
 
 
@@ -61,4 +61,4 @@ class EnumFieldTests(TestCase):
                 obj.save()
 
     def test_choices(self):
-        self.assertEqual(Status.choices(), list(Status._enum_values.items()))
+        self.assertEqual(Status.choices, list(Status._enum_values.items()))

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,11 +21,11 @@ class EnumTests(TestCase):
     def test_enum_choices(self):
         self.assertEqual(
             [
-                ('STATUS_ONE', Status.STATUS_ONE),
-                ('STATUS_TWO', Status.STATUS_TWO),
-                ('STATUS_THREE', Status.STATUS_THREE)
+                (Status.STATUS_ONE, 'STATUS_ONE'),
+                (Status.STATUS_TWO, 'STATUS_TWO'),
+                (Status.STATUS_THREE, 'STATUS_THREE')
             ],
-            Status._choices
+            Status.choices()
         )
 
 
@@ -61,5 +61,4 @@ class EnumFieldTests(TestCase):
                 obj.save()
 
     def test_choices(self):
-        self.assertEqual(Status.choices(), Status._choices)
-        self.assertFalse(Status.choices() is Status._choices)
+        self.assertEqual(Status.choices(), Status._enum_values.items())


### PR DESCRIPTION
Two main changes to the API:

- Making the get methods more forgiving, like dict.get, and returning None if the name or value is not present.
- Implementing `name_values` as the inverse of `choices`.

It should be noted that `choices()` wasn't present, but was de-facto
implemented in the init of the field. However, it was implemented in the
opposite order (name, value) from how Django Field.choices() works. I have
reversed the order to bring it in line with expectations from the Django
standard library.