### PR TITLE
Implement EnumType.is_valid_name

### DIFF
--- a/django_light_enums/enum.py
+++ b/django_light_enums/enum.py
@@ -26,6 +26,9 @@ class EnumType(type):
     def is_valid_value(cls, value):
         return value in cls._enum_values.keys()
 
+    def is_valid_name(cls, value):
+        return value in cls._enum_values.values()
+
     @property
     def enum_values(cls):
         return cls._enum_values.keys()

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,6 +28,11 @@ class EnumTests(TestCase):
             Status.choices
         )
 
+    def test_enum_is_valid_name(self):
+        self.assertTrue(Status.is_valid_name('STATUS_ONE'))
+        self.assertTrue(Status.is_valid_name('STATUS_TWO'))
+        self.assertTrue(Status.is_valid_name('STATUS_THREE'))
+        self.assertFalse(Status.is_valid_name('STATUS_ZERO'))
 
 class EnumFieldTests(TestCase):
 


### PR DESCRIPTION
The helper methods have parity between `values` and `names`...except for the `is_valid` lookup. This PR fills in the missing method.